### PR TITLE
use -> for return type

### DIFF
--- a/serqlane/astcompiler.py
+++ b/serqlane/astcompiler.py
@@ -782,6 +782,9 @@ class CompCtx(lark.visitors.Interpreter):
         # TODO: Error reporting
         raise ValueError(f"Bad identifier: {val}")
 
+    def return_user_type(self, tree: Tree, expected_type: Type):
+        return self.user_type(tree, expected_type)
+
     def user_type(self, tree: Tree, expected_type: Type):
         return self.visit(tree.children[0], None) # TODO: Enforce `type` metatype
 

--- a/serqlane/grammar.lark
+++ b/serqlane/grammar.lark
@@ -1,6 +1,6 @@
 start: statement*
 
-fn_definition: "fn" identifier fn_definition_args [user_type] block_stmt
+fn_definition: "fn" identifier fn_definition_args [return_user_type] block_stmt
 fn_definition_args: "(" [fn_definition_arg ("," fn_definition_arg)*] ")"
 fn_definition_arg: identifier user_type
 
@@ -9,6 +9,7 @@ fn_call_args: "(" [expression ("," expression)*] ")"
 statement: ((return_stmt | break_stmt | continue_stmt | expression | assignment | let_stmt) _TERMINATOR) | (fn_definition | block_stmt | while_stmt | if_stmt)
 
 user_type: ":" expression
+return_user_type: "->" expression
 
 let_stmt: "let" MUT? identifier user_type? "=" expression
 MUT: "mut"

--- a/serqlane/vm.py
+++ b/serqlane/vm.py
@@ -231,8 +231,8 @@ let x = 1
     let y = 2
 }
 
-fn add(w: int): int {
-    w
+fn add(w: int) -> int {
+    return w
 }
 """
 


### PR DESCRIPTION
replaces : with -> such as
```
fn foo(w: int) -> int {
    w
}
```

-> is much clearer to denote the return type of the function rather than :

: seems more like it's refering to the type of something pre-body whereas -> is more clear that it's something post-body