### PR TITLE
fix functions with no args

### DIFF
--- a/serqlane/astcompiler.py
+++ b/serqlane/astcompiler.py
@@ -908,6 +908,10 @@ class CompCtx(lark.visitors.Interpreter):
         assert expected_type.kind == TypeKind.unit
 
         params = []
+
+        if len(tree.children) == 1 and tree.children[0] is None:
+            return NodeFnParameters(params)
+
         for child in tree.children:
             assert child.data == "fn_definition_arg"
             # TODO: Mutable args

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -64,3 +64,11 @@ dbg(w)
 """
 
     assert capture_first_debug(code) == 4
+
+
+def test_function_empty_args(executor):
+    executor("""
+fn abc() {
+    return
+}
+""")


### PR DESCRIPTION
fixes functions with no args
i.e.
```
fn abc() {
    return
}
```

also adds a test to ensure it doesn't return