### PR TITLE
fix empty literals

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -18,3 +18,8 @@ fn add(a: int, b: int) -> string {
 let x = add(1, 1)
 """
         )
+
+
+def test_empty_literal(capture_first_debug):
+    assert capture_first_debug("dbg(\"\")") == ""
+


### PR DESCRIPTION
fixes empty literals and adds easy support for future ones

i.e.
```
let x = ""
```

also adds a test for this