### PR TITLE
add reserved keywords and associated tests

### DIFF
--- a/serqlane/astcompiler.py
+++ b/serqlane/astcompiler.py
@@ -880,8 +880,6 @@ class CompCtx(lark.visitors.Interpreter):
         ident_node = tree.children[f]
         assert ident_node.data == "identifier"
         ident = ident_node.children[0].value
-        if ident in RESERVED_KEYWORDS:
-            raise ValueError(f"Cannot use reserved keyword `{ident}` as a variable name")
 
         f += 1
 
@@ -967,8 +965,6 @@ class CompCtx(lark.visitors.Interpreter):
         ident_node = tree.children[0]
         assert ident_node.data == "identifier"
         ident = ident_node.children[0].value
-        if ident in RESERVED_KEYWORDS:
-            raise ValueError(f"Cannot use reserved keyword `{ident}` as a function name")
 
         # must open a scope here to isolate the params
         fn_scope = self.current_scope.make_child()

--- a/serqlane/astcompiler.py
+++ b/serqlane/astcompiler.py
@@ -12,6 +12,21 @@ from lark import Token, Tree
 from serqlane.parser import SerqParser
 
 
+RESERVED_KEYWORDS = [
+    "and",
+    "break",
+    "continue",
+    "else",
+    "fn",
+    "if",
+    "let",
+    "mut",
+    "not",
+    "or",
+    "return",
+    "while",
+]
+
 class Node:
     def __init__(self, type: Type) -> None:
         assert type != None and isinstance(type, Type)
@@ -855,6 +870,8 @@ class CompCtx(lark.visitors.Interpreter):
         ident_node = tree.children[f]
         assert ident_node.data == "identifier"
         ident = ident_node.children[0].value
+        if ident in RESERVED_KEYWORDS:
+            raise ValueError(f"Cannot use reserved keyword `{ident}` as a variable name")
 
         f += 1
 
@@ -940,7 +957,8 @@ class CompCtx(lark.visitors.Interpreter):
         ident_node = tree.children[0]
         assert ident_node.data == "identifier"
         ident = ident_node.children[0].value
-
+        if ident in RESERVED_KEYWORDS:
+            raise ValueError(f"Cannot use reserved keyword `{ident}` as a function name")
 
         # must open a scope here to isolate the params
         fn_scope = self.current_scope.make_child()

--- a/serqlane/astcompiler.py
+++ b/serqlane/astcompiler.py
@@ -606,12 +606,12 @@ class CompCtx(lark.visitors.Interpreter):
     def check_reserved_keywords(self, tree):
         if isinstance(tree, Tree):
             if tree.data == 'identifier' and tree.children[0].value in RESERVED_KEYWORDS:
-                raise ValueError(f"Cannot use reserved keyword `{tree.children[0].value}` as a variable name")
+                raise ValueError(f"Cannot use reserved keyword `{tree.children[0].value}` as a symbol name")
             for child in tree.children:
                 self.check_reserved_keywords(child)
         elif isinstance(tree, Token):
             if tree.type == 'identifier' and tree.value in RESERVED_KEYWORDS:
-                raise ValueError(f"Cannot use reserved keyword `{tree.value}` as a variable name")
+                raise ValueError(f"Cannot use reserved keyword `{tree.value}` as a symbol name")
 
     # new functions
     def statement(self, tree: Tree, expected_type: Type):

--- a/serqlane/astcompiler.py
+++ b/serqlane/astcompiler.py
@@ -603,10 +603,20 @@ class CompCtx(lark.visitors.Interpreter):
         raise ValueError(f"{tree=}")
         return self.visit_children(tree, expected_type)
 
+    def check_reserved_keywords(self, tree):
+        if isinstance(tree, Tree):
+            if tree.data == 'identifier' and tree.children[0].value in RESERVED_KEYWORDS:
+                raise ValueError(f"Cannot use reserved keyword `{tree.children[0].value}` as a variable name")
+            for child in tree.children:
+                self.check_reserved_keywords(child)
+        elif isinstance(tree, Token):
+            if tree.type == 'identifier' and tree.value in RESERVED_KEYWORDS:
+                raise ValueError(f"Cannot use reserved keyword `{tree.value}` as a variable name")
 
     # new functions
     def statement(self, tree: Tree, expected_type: Type):
         assert len(tree.children) == 1, f"{len(tree.children)} --- {tree.children=}"
+        self.check_reserved_keywords(tree.children[0])
         return self.visit(tree.children[0], expected_type)
 
 

--- a/tests/test_reserved_keywords.py
+++ b/tests/test_reserved_keywords.py
@@ -1,26 +1,12 @@
 import pytest
+from serqlane.astcompiler import RESERVED_KEYWORDS
 
-reserved_keywords = [
-    "and",
-    "break",
-    "continue",
-    "else",
-    "fn",
-    "if",
-    "let",
-    "mut",
-    "not",
-    "or",
-    "return",
-    "while",
-]
-
-@pytest.mark.parametrize("keyword", reserved_keywords)
+@pytest.mark.parametrize("keyword", RESERVED_KEYWORDS)
 def test_let_reserved_keywords(executor, keyword):
     with pytest.raises(ValueError):
         executor(f"let {keyword} = 1")
 
-@pytest.mark.parametrize("keyword", reserved_keywords)
+@pytest.mark.parametrize("keyword", RESERVED_KEYWORDS)
 def test_fn_name_reserved_keywords(executor, keyword):
     with pytest.raises(ValueError):
         code = f"""
@@ -29,7 +15,7 @@ def test_fn_name_reserved_keywords(executor, keyword):
         }}"""
         executor(code)
 
-@pytest.mark.parametrize("keyword", reserved_keywords)
+@pytest.mark.parametrize("keyword", RESERVED_KEYWORDS)
 def test_fn_args_reserved_keywords(executor, keyword):
     with pytest.raises(ValueError):
         code = f"""

--- a/tests/test_reserved_keywords.py
+++ b/tests/test_reserved_keywords.py
@@ -1,0 +1,30 @@
+import pytest
+
+reserved_keywords = [
+    "and",
+    "break",
+    "continue",
+    "else",
+    "fn",
+    "if",
+    "let",
+    "mut",
+    "not",
+    "or",
+    "return",
+    "while",
+]
+
+@pytest.mark.parametrize("keyword", reserved_keywords)
+def test_let_reserved_keywords(executor, keyword):
+    with pytest.raises(ValueError):
+        executor(f"let {keyword} = 1")
+
+@pytest.mark.parametrize("keyword", reserved_keywords)
+def test_fn_reserved_keywords(executor, keyword):
+    with pytest.raises(ValueError):
+        code = f"""
+        fn {keyword}() {{
+            return 
+        }}"""
+        executor(code)

--- a/tests/test_reserved_keywords.py
+++ b/tests/test_reserved_keywords.py
@@ -21,10 +21,19 @@ def test_let_reserved_keywords(executor, keyword):
         executor(f"let {keyword} = 1")
 
 @pytest.mark.parametrize("keyword", reserved_keywords)
-def test_fn_reserved_keywords(executor, keyword):
+def test_fn_name_reserved_keywords(executor, keyword):
     with pytest.raises(ValueError):
         code = f"""
         fn {keyword}() {{
-            return 
+            return
+        }}"""
+        executor(code)
+
+@pytest.mark.parametrize("keyword", reserved_keywords)
+def test_fn_args_reserved_keywords(executor, keyword):
+    with pytest.raises(ValueError):
+        code = f"""
+        fn test({keyword}: int) {{
+            return
         }}"""
         executor(code)


### PR DESCRIPTION
This PR aims to solve https://github.com/serqlane/serqlane/issues/39. It's a rather naive approach given we need to supply a list of keywords but it works well.

That being said Python has these as reserved words which is somewhat small.
```
['False', 'None', 'True', 'and', 'as', 'assert', 'async', 'await', 'break', 'class', 'continue', 'def', 'del', 'elif', 'else', 'except', 'finally', 'for', 'from', 'global', 'if', 'import', 'in', 'is', 'lambda', 'nonlocal', 'not', 'or', 'pass', 'raise', 'return', 'try', 'while', 'with', 'yield']
```