### PR TITLE
Line and column information for relevant nodes

### DIFF
--- a/serqlane/astcompiler.py
+++ b/serqlane/astcompiler.py
@@ -30,10 +30,18 @@ RESERVED_KEYWORDS = [
     "while",
 ]
 
+class LineInfo:
+    def __init__(self, line: int, line_end: int, column: int, column_end: int):
+        self.line = line
+        self.line_end = line_end
+        self.column = column
+        self.column_end = column_end
+
 class Node:
     def __init__(self, type: Type) -> None:
         assert type != None and isinstance(type, Type)
         self.type = type
+        self.lineinfo: Optional[LineInfo] = None
 
     def render(self) -> str:
         raise NotImplementedError(f"{type(self)}")

--- a/serqlane/parser.py
+++ b/serqlane/parser.py
@@ -13,7 +13,7 @@ class SerqParser:
         with open(grammar_file) as fp:
             grammar = fp.read()
 
-        self.lark = Lark(grammar)
+        self.lark = Lark(grammar, propagate_positions=True)
 
     def parse(self, entry: str, display: bool = False):
         if not entry.endswith("\n"):


### PR DESCRIPTION
Preparation for better error reporting