### PR TITLE
switch to 3.11

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         self',
         ...
       }: let
-        python = pkgs.python312;
+        python = pkgs.python311;
         pyproject = builtins.fromTOML (builtins.readFile ./pyproject.toml);
         packageName = "serqlane";
       in {

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,13 +32,13 @@ files = [
 
 [[package]]
 name = "hypothesis"
-version = "6.96.1"
+version = "6.97.0"
 description = "A library for property-based testing"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "hypothesis-6.96.1-py3-none-any.whl", hash = "sha256:848ea0952f0bdfd02eac59e41b03f1cbba8fa2cffeffa8db328bbd6cfe159974"},
-    {file = "hypothesis-6.96.1.tar.gz", hash = "sha256:955a57e56be4607c81c17ca53e594af54aadeed91e07b88bb7f84e8208ea7739"},
+    {file = "hypothesis-6.97.0-py3-none-any.whl", hash = "sha256:4e4950cdc0673e8d69353400f69854bf28c14914861b1d560d4bca55772d6b52"},
+    {file = "hypothesis-6.97.0.tar.gz", hash = "sha256:c7e27219a03c21e0f8e66e61ae57e724a53b2c9480e1a919567fc77b0b16e868"},
 ]
 
 [package.dependencies]
@@ -103,13 +103,13 @@ files = [
 
 [[package]]
 name = "pluggy"
-version = "1.3.0"
+version = "1.4.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pluggy-1.3.0-py3-none-any.whl", hash = "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"},
-    {file = "pluggy-1.3.0.tar.gz", hash = "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12"},
+    {file = "pluggy-1.4.0-py3-none-any.whl", hash = "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981"},
+    {file = "pluggy-1.4.0.tar.gz", hash = "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"},
 ]
 
 [package.extras]
@@ -180,5 +180,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.12"
-content-hash = "b490966fe865bc80da9cb9a8a18ee114e3cdc1f3ff62c4032e691dd19cf59e0d"
+python-versions = "^3.11"
+content-hash = "7e668dd18dd2b9710452c330fdfb0999c407eda7fe8b5fbc7f3328121b82914c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.3"

--- a/serqlane/astcompiler.py
+++ b/serqlane/astcompiler.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
 from enum import Enum, auto
-from typing import Any, Optional, Iterator
+from typing import Any, Optional, Iterator, Generic, TypeVar
 
 import pathlib
 import hashlib
 import textwrap
-import warnings
 
 from serqlane.parser import Token, Tree, SerqParser
 from serqlane.common import SerqInternalError
 
+
+T = TypeVar("T")
 
 DEBUG = False
 
@@ -103,7 +104,7 @@ class NodeStmtList(Node):
             result.append(child.render())
         return "\n".join(result)
 
-class NodeLiteral[T](Node):
+class NodeLiteral(Node, Generic[T]):
     def __init__(self, value: T, type: Type) -> None:
         super().__init__(type) # type either gets converted from literal to actual, gets turned into an error or gets inferred from lhs
         self.value = value
@@ -121,11 +122,11 @@ class NodeBoolLit(NodeLiteral[bool]):
 
 class NodeStringLit(NodeLiteral[str]):
     def render(self) -> str:
-        return f"\"{self.value.encode("unicode_escape").decode("utf-8")}\""
+        return f'\"{self.value.encode("unicode_escape").decode("utf-8")}\"'
 
 class NodeCharLit(NodeLiteral[str]):
     def render(self) -> str:
-        return f"'{self.value.encode("unicode_escape").decode("utf-8")}'"
+        return f"'{self.value.encode('unicode_escape').decode('utf-8')}'"
 
 class NodeLet(Node):
     def __init__(self, sym_node: NodeSymbol, expr: Node, type: Type):
@@ -135,7 +136,7 @@ class NodeLet(Node):
 
     def render(self) -> str:
         is_mut = self.sym_node.symbol.mutable or self.sym_node.symbol.hidden_mutable
-        return f"let {"mut " if is_mut else ""}{self.sym_node.render()}{": " + self.sym_node.type.render()} = {self.expr.render()}"
+        return f'let {"mut " if is_mut else ""}{self.sym_node.render()}{": " + self.sym_node.type.render()} = {self.expr.render()}'
 
 class NodeConst(Node):
     def __init__(self, sym_node: NodeSymbol, expr: Node, type: Type):
@@ -272,7 +273,7 @@ class NodeBlockStmt(NodeStmtList):
 
     def render(self) -> str:
         inner = super().render()
-        return f"{{\n{textwrap.indent(inner, "  ")}\n}}"
+        return f"{{\n{textwrap.indent(inner, '  ')}\n}}"
 
 class NodeWhileStmt(Node):
     def __init__(self, cond_expr: Node, body: NodeBlockStmt, type: Type) -> None:

--- a/serqlane/vm.py
+++ b/serqlane/vm.py
@@ -101,7 +101,7 @@ class SerqVM:
         self.stack: list[dict[Symbol, Any]] = []
         self.types: dict[int, Any] = {}
 
-    def construct_serq_struct(self, struct: NodeStructDefinition):
+    def construct_serq_struct(self, struct: NodeStructDefinition) -> type[ctypes.Structure]:
         name = struct.sym.name
 
         fields: list[tuple[str, ctypes._SimpleCData]] = []
@@ -332,7 +332,7 @@ class SerqVM:
 
         raise KeyError(f"{symbol} not found in scope")
 
-    def put_type(self, id: int, typ: Type):
+    def put_type(self, id: int, typ: type[ctypes.Structure]):
         self.types[id] = typ
 
     def fetch_type(self, id: int) -> Any:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,14 @@
 import pathlib
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TypeAlias
 import pytest
 
 from serqlane.vm import SerqVM
 from serqlane.astcompiler import ModuleGraph, Module, MAGIC_MODULE_NAME
 
 
-type ModuleMap = dict[str, str]
+ModuleMap: TypeAlias = dict[str, str]
 
 
 # https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option


### PR DESCRIPTION
downgrade to 3.11 to allow usage of compiled extensions (namely llvmlite) which seem to need until 3.13 to update for some reason